### PR TITLE
Harden pointer resolution for SQS payloads with defensive parsing

### DIFF
--- a/src/ResolvesPointers.php
+++ b/src/ResolvesPointers.php
@@ -14,7 +14,20 @@ trait ResolvesPointers
      */
     protected function resolvePointer(): ?string
     {
-        return json_decode($this->job['Body'])->pointer ?? null;
+        $body = $this->job['Body'] ?? null;
+        if (!is_string($body) || $body === '') {
+            return null;
+        }
+
+        $decoded = json_decode($body); // stdClass|array|null
+        if (!is_object($decoded) || !property_exists($decoded, 'pointer')) {
+            return null;
+        }
+
+        $pointer = $decoded->pointer;
+        return is_string($pointer)
+            ? $pointer
+            : (is_scalar($pointer) ? (string) $pointer : null);
     }
 
     /**

--- a/src/ResolvesPointers.php
+++ b/src/ResolvesPointers.php
@@ -15,16 +15,17 @@ trait ResolvesPointers
     protected function resolvePointer(): ?string
     {
         $body = $this->job['Body'] ?? null;
-        if (!is_string($body) || $body === '') {
+        if (! is_string($body) || $body === '') {
             return null;
         }
 
-        $decoded = json_decode($body); // stdClass|array|null
-        if (!is_object($decoded) || !property_exists($decoded, 'pointer')) {
+        $decoded = json_decode($body);
+        if (! is_object($decoded) || ! property_exists($decoded, 'pointer')) {
             return null;
         }
 
         $pointer = $decoded->pointer;
+
         return is_string($pointer)
             ? $pointer
             : (is_scalar($pointer) ? (string) $pointer : null);

--- a/tests/ResolvesPointersTest.php
+++ b/tests/ResolvesPointersTest.php
@@ -29,37 +29,37 @@ final class ResolvesPointersTest extends TestCase
 
     public function test_it_returns_null_when_body_is_empty(): void
     {
-        $s = $this->makeSubject(['Body' => '']);
-        $this->assertNull($this->callResolvePointer($s));
+        $subject = $this->makeSubject(['Body' => '']);
+        $this->assertNull($this->callResolvePointer($subject));
     }
 
     public function test_it_returns_null_when_body_is_invalid_json(): void
     {
-        $s = $this->makeSubject(['Body' => '{']);
-        $this->assertNull($this->callResolvePointer($s));
+        $subject = $this->makeSubject(['Body' => '{']);
+        $this->assertNull($this->callResolvePointer($subject));
     }
 
     public function test_it_returns_null_when_pointer_is_missing(): void
     {
-        $s = $this->makeSubject(['Body' => json_encode((object) ['foo' => 'bar'])]);
-        $this->assertNull($this->callResolvePointer($s));
+        $subject = $this->makeSubject(['Body' => json_encode((object) ['foo' => 'bar'])]);
+        $this->assertNull($this->callResolvePointer($subject));
     }
 
     public function test_it_returns_pointer_string_when_present(): void
     {
-        $s = $this->makeSubject(['Body' => json_encode((object) ['pointer' => 'manuals/a.pdf'])]);
-        $this->assertSame('manuals/a.pdf', $this->callResolvePointer($s));
+        $subject = $this->makeSubject(['Body' => json_encode((object) ['pointer' => 'manuals/a.pdf'])]);
+        $this->assertSame('manuals/a.pdf', $this->callResolvePointer($subject));
     }
 
     public function test_it_casts_numeric_pointer_to_string(): void
     {
-        $s = $this->makeSubject(['Body' => json_encode((object) ['pointer' => 12345])]);
-        $this->assertSame('12345', $this->callResolvePointer($s));
+        $subject = $this->makeSubject(['Body' => json_encode((object) ['pointer' => 12345])]);
+        $this->assertSame('12345', $this->callResolvePointer($subject));
     }
 
     public function test_it_resolves_the_configured_disk_adapter(): void
     {
-        $s = $this->makeSubject(['Body' => '{}'], ['disk' => 'archive']);
+        $subject = $this->makeSubject(['Body' => '{}'], ['disk' => 'archive']);
 
         $manager = Mockery::mock(FilesystemManager::class);
         $adapter = Mockery::mock(FilesystemAdapter::class);
@@ -69,22 +69,24 @@ final class ResolvesPointersTest extends TestCase
             ->with('archive')
             ->andReturn($adapter);
 
-        $s->container->instance('filesystem', $manager);
+        $subject->container->instance('filesystem', $manager);
 
-        $this->assertSame($adapter, $this->callResolveDisk($s));
+        $this->assertSame($adapter, $this->callResolveDisk($subject));
     }
 
     private function callResolvePointer(object $obj): ?string
     {
-        $m = new ReflectionMethod($obj, 'resolvePointer');
-        $m->setAccessible(true);
-        return $m->invoke($obj);
+        $method = new ReflectionMethod($obj, 'resolvePointer');
+        $method->setAccessible(true);
+
+        return $method->invoke($obj);
     }
 
     private function callResolveDisk(object $obj): FilesystemAdapter
     {
-        $m = new ReflectionMethod($obj, 'resolveDisk');
-        $m->setAccessible(true);
-        return $m->invoke($obj);
+        $method = new ReflectionMethod($obj, 'resolveDisk');
+        $method->setAccessible(true);
+
+        return $method->invoke($obj);
     }
 }

--- a/tests/ResolvesPointersTest.php
+++ b/tests/ResolvesPointersTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DefectiveCode\LaravelSqsExtended\Tests;
+
+use Mockery;
+use ReflectionMethod;
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Filesystem\FilesystemManager;
+
+final class ResolvesPointersTest extends TestCase
+{
+    private function makeSubject(array $job, array $diskOptions = ['disk' => 's3'])
+    {
+        return new class ($job, $diskOptions) {
+            use \DefectiveCode\LaravelSqsExtended\ResolvesPointers;
+
+            public ContainerContract $container;
+
+            public function __construct(public array $job, public array $diskOptions)
+            {
+                $this->container = new Container();
+            }
+        };
+    }
+
+    public function test_it_returns_null_when_body_is_empty(): void
+    {
+        $s = $this->makeSubject(['Body' => '']);
+        $this->assertNull($this->callResolvePointer($s));
+    }
+
+    public function test_it_returns_null_when_body_is_invalid_json(): void
+    {
+        $s = $this->makeSubject(['Body' => '{']);
+        $this->assertNull($this->callResolvePointer($s));
+    }
+
+    public function test_it_returns_null_when_pointer_is_missing(): void
+    {
+        $s = $this->makeSubject(['Body' => json_encode((object) ['foo' => 'bar'])]);
+        $this->assertNull($this->callResolvePointer($s));
+    }
+
+    public function test_it_returns_pointer_string_when_present(): void
+    {
+        $s = $this->makeSubject(['Body' => json_encode((object) ['pointer' => 'manuals/a.pdf'])]);
+        $this->assertSame('manuals/a.pdf', $this->callResolvePointer($s));
+    }
+
+    public function test_it_casts_numeric_pointer_to_string(): void
+    {
+        $s = $this->makeSubject(['Body' => json_encode((object) ['pointer' => 12345])]);
+        $this->assertSame('12345', $this->callResolvePointer($s));
+    }
+
+    public function test_it_resolves_the_configured_disk_adapter(): void
+    {
+        $s = $this->makeSubject(['Body' => '{}'], ['disk' => 'archive']);
+
+        $manager = Mockery::mock(FilesystemManager::class);
+        $adapter = Mockery::mock(FilesystemAdapter::class);
+
+        $manager->shouldReceive('disk')
+            ->once()
+            ->with('archive')
+            ->andReturn($adapter);
+
+        $s->container->instance('filesystem', $manager);
+
+        $this->assertSame($adapter, $this->callResolveDisk($s));
+    }
+
+    private function callResolvePointer(object $obj): ?string
+    {
+        $m = new ReflectionMethod($obj, 'resolvePointer');
+        $m->setAccessible(true);
+        return $m->invoke($obj);
+    }
+
+    private function callResolveDisk(object $obj): FilesystemAdapter
+    {
+        $m = new ReflectionMethod($obj, 'resolveDisk');
+        $m->setAccessible(true);
+        return $m->invoke($obj);
+    }
+}


### PR DESCRIPTION
### what i have done

- Validate Body presence and type before json_decode.

- Ensure decoded payload is an object and actually contains pointer.

- Safely coerce scalar pointers to string; reject non-scalars.

- Improves behaviour under malformed/third-party messages and avoids PHP notices/fatals.


### test results
<img width="672" height="467" alt="スクリーンショット 2025-10-16 10 13 04" src="https://github.com/user-attachments/assets/8861a4b1-4d75-409e-a236-ff7e8e2c91ce" />
