### PR TITLE
Upgrade PHPunit, Resolve issue with Vapor core 2, require PHP 8.4

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.2, 8.3]
+                php: [8.4]    
 
         name: P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: true
             matrix:
                 os: [ubuntu-latest]
-                php: [8.4]    
+                php: [8.4]
 
         name: P${{ matrix.php }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "^8.4",
-        "aws/aws-sdk-php": "3.368.0.0",
+        "aws/aws-sdk-php": "^3.368.0.0",
         "illuminate/container": "^10.0 || ^11.0 || ^12.0",
         "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
         "illuminate/filesystem": "^10.0 || ^11.0 || ^12.0",

--- a/composer.json
+++ b/composer.json
@@ -19,24 +19,22 @@
         }
     ],
     "suggest": {
-        "laravel/vapor-core": "Allows SQS disk based storage while using Laravel Vapor."
+        "laravel/vapor-core": "Required for SQS disk-based storage when using Laravel Vapor."
     },
     "require": {
-        "php": ">=8.2",
-        "aws/aws-sdk-php": "^3.189.0",
-        "league/flysystem": "~3",
-        "illuminate/container": "~9|~10|~11|^12.0",
-        "illuminate/contracts": "~9|~10|~11|^12.0",
-        "illuminate/filesystem": "~9|~10|~11|^12.0",
-        "illuminate/queue": "~9|~10|~11|^12.0",
-        "illuminate/support": "~9|~10|~11|^12.0"
+        "php": "^8.4",
+        "aws/aws-sdk-php": "3.368.0.0",
+        "illuminate/container": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/contracts": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/filesystem": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/queue": "^10.0 || ^11.0 || ^12.0",
+        "illuminate/support": "^10.0 || ^11.0 || ^12.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^8.3|^10.0",
-        "nunomaduro/collision": "^7.0",
-        "phpunit/phpunit": "^10.0|^11.5.3",
         "laravel/pint": "^1.8",
-        "mockery/mockery": "^1.6"
+        "mockery/mockery": "^1.6",
+        "orchestra/testbench": "^8.0 || ^9.0 || ^10.0",
+        "phpunit/phpunit": "^12.0"
     },
     "extra": {
         "laravel": {

--- a/src/SqsDiskQueue.php
+++ b/src/SqsDiskQueue.php
@@ -66,11 +66,14 @@ class SqsDiskQueue extends SqsQueue
         ];
 
         if (strlen($payload) >= self::MAX_SQS_LENGTH || Arr::get($this->diskOptions, 'always_store')) {
-            $uuid = json_decode($payload)->uuid;
-            $filepath = Arr::get($this->diskOptions, 'prefix', '')."/{$uuid}.json";
+            $decodedPayload = json_decode($payload);
+            $filepath = Arr::get($this->diskOptions, 'prefix', '')."/{$decodedPayload->uuid}.json";
             $this->resolveDisk()->put($filepath, $payload);
 
-            $message['MessageBody'] = json_encode(['pointer' => $filepath]);
+            $message['MessageBody'] = json_encode([
+                'pointer' => $filepath,
+                'job' => $decodedPayload->job ?? null,
+            ]);
         }
 
         if ($delay) {

--- a/src/SqsDiskServiceProvider.php
+++ b/src/SqsDiskServiceProvider.php
@@ -14,7 +14,7 @@ class SqsDiskServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $manager = $this->app->make('queue');
-        $manager->addConnector('sqs-disk', fn () => new SqsDiskConnector());
+        $manager->addConnector('sqs-disk', fn () => new SqsDiskConnector);
 
         $this->app->extend('command.vapor.work', fn () => new VaporWorkCommand($this->app['queue.vaporWorker']));
     }

--- a/tests/SqsDiskConnectorTest.php
+++ b/tests/SqsDiskConnectorTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DefectiveCode\LaravelSqsExtended\Tests;
+
+use DefectiveCode\LaravelSqsExtended\SqsDiskQueue;
+use DefectiveCode\LaravelSqsExtended\SqsDiskConnector;
+
+class SqsDiskConnectorTest extends TestCase
+{
+    public function testItCreatesSqsDiskQueueInstance(): void
+    {
+        $connector = new SqsDiskConnector;
+
+        $config = [
+            'key' => 'test-key',
+            'secret' => 'test-secret',
+            'region' => 'us-east-1',
+            'queue' => 'default',
+            'prefix' => 'https://sqs.us-east-1.amazonaws.com/123456789',
+            'suffix' => '',
+            'after_commit' => false,
+            'disk_options' => [
+                'always_store' => false,
+                'cleanup' => true,
+                'disk' => 's3',
+                'prefix' => 'queue-payloads',
+            ],
+        ];
+
+        $queue = $connector->connect($config);
+
+        $this->assertInstanceOf(SqsDiskQueue::class, $queue);
+    }
+}

--- a/tests/SqsDiskJobTest.php
+++ b/tests/SqsDiskJobTest.php
@@ -23,9 +23,12 @@ class SqsDiskJobTest extends TestCase
 
     private Container $mockedContainer;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
-        $mockedPayload = json_encode(['pointer' => 'prefix/e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81.json']);
+        $mockedPayload = json_encode([
+            'pointer' => 'prefix/e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81.json',
+            'job' => 'App\\Jobs\\SomeJob',
+        ]);
         $mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
         $mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
 

--- a/tests/SqsDiskQueueTest.php
+++ b/tests/SqsDiskQueueTest.php
@@ -35,11 +35,14 @@ class SqsDiskQueueTest extends TestCase
 
     private Container $mockedContainer;
 
-    public function setUp(): void
+    protected function setUp(): void
     {
         $this->mockedMessageId = 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81';
         $this->mockedPayload = json_encode(['job' => 'foo', 'data' => ['data'], 'uuid' => $this->mockedMessageId]);
-        $this->mockedPointerPayload = json_encode(['pointer' => 'prefix/e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81.json']);
+        $this->mockedPointerPayload = json_encode([
+            'pointer' => 'prefix/e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81.json',
+            'job' => 'foo',
+        ]);
         $this->mockedLargePayload = json_encode(['job' => 'foo', 'data' => [base64_encode(random_bytes(262144))], 'uuid' => $this->mockedMessageId]);
         $this->mockedReceiptHandle = '0NNAq8PwvXuWv5gMtS9DJ8qEdyiUwbAjpp45w2m6M4SJ1Y+PxCh7R930NRB8ylSacEmoSnW18bgd4nK\/O6ctE+VFVul4eD23mA07vVoSnPI4F\/voI1eNCp6Iax0ktGmhlNVzBwaZHEr91BRtqTRM3QKd2ASF8u+IQaSwyl\/DGK+P1+dqUOodvOVtExJwdyDLy1glZVgm85Yw9Jf5yZEEErqRwzYz\/qSigdvW4sm2l7e4phRol\/+IjMtovOyH\/ukueYdlVbQ4OshQLENhUKe7RNN5i6bE\/e5x9bnPhfj2gbM';
 
@@ -266,6 +269,8 @@ class SqsDiskQueueTest extends TestCase
             ->andReturn(new Result([
                 'Attributes' => [
                     'ApproximateNumberOfMessages' => 1,
+                    'ApproximateNumberOfMessagesDelayed' => 0,
+                    'ApproximateNumberOfMessagesNotVisible' => 0,
                 ],
             ]));
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -10,7 +10,7 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/VaporSqsDiskJobTest.php
+++ b/tests/VaporSqsDiskJobTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DefectiveCode\LaravelSqsExtended\Tests;
+
+use Mockery;
+use Aws\Sqs\SqsClient;
+use Illuminate\Container\Container;
+use Illuminate\Filesystem\FilesystemAdapter;
+use DefectiveCode\LaravelSqsExtended\SqsDiskQueue;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+class VaporSqsDiskJobTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    protected SqsClient $mockedSqsClient;
+
+    protected FilesystemAdapter $mockedFilesystemAdapter;
+
+    protected Container $mockedContainer;
+
+    protected ?string $capturedMessageBody = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mockedSqsClient = Mockery::mock(SqsClient::class);
+        $this->mockedFilesystemAdapter = Mockery::mock(FilesystemAdapter::class);
+        $this->mockedContainer = Mockery::mock(Container::class)->makePartial();
+    }
+
+    public function testOldPointerFormatFailsVaporDetection(): void
+    {
+        $payload = json_encode(['pointer' => 'prefix/uuid.json']);
+
+        $this->assertFalse($this->simulateVaporQueueDetection($payload));
+    }
+
+    public function testNewPointerFormatPassesVaporDetection(): void
+    {
+        $payload = json_encode([
+            'pointer' => 'prefix/uuid.json',
+            'job' => 'App\\Jobs\\ProcessPodcast',
+        ]);
+
+        $this->assertTrue($this->simulateVaporQueueDetection($payload));
+    }
+
+    public function testRegularPayloadPassesVaporDetection(): void
+    {
+        $payload = json_encode([
+            'uuid' => 'some-uuid',
+            'job' => 'Illuminate\\Queue\\CallQueuedHandler@call',
+            'data' => ['command' => 'serialized-command'],
+        ]);
+
+        $this->assertTrue($this->simulateVaporQueueDetection($payload));
+    }
+
+    public function testLargePayloadIncludesJobPropertyForVaporDetection(): void
+    {
+        $this->setUpDiskStorageMocks();
+
+        $payload = json_encode([
+            'uuid' => 'test-uuid-123',
+            'job' => 'Illuminate\\Queue\\CallQueuedHandler@call',
+            'data' => ['command' => base64_encode(random_bytes(262144))],
+        ]);
+
+        $this->createQueue()->pushRaw($payload);
+
+        $this->assertTrue($this->simulateVaporQueueDetection($this->capturedMessageBody));
+
+        $decodedBody = json_decode($this->capturedMessageBody);
+        $this->assertEquals('queue-jobs/test-uuid-123.json', $decodedBody->pointer);
+        $this->assertEquals('Illuminate\\Queue\\CallQueuedHandler@call', $decodedBody->job);
+    }
+
+    public function testAlwaysStoreIncludesJobProperty(): void
+    {
+        $this->setUpDiskStorageMocks();
+
+        $payload = json_encode([
+            'uuid' => 'small-uuid-456',
+            'job' => 'App\\Jobs\\SmallJob',
+            'data' => ['key' => 'value'],
+        ]);
+
+        $this->createQueue(alwaysStore: true)->pushRaw($payload);
+
+        $this->assertTrue($this->simulateVaporQueueDetection($this->capturedMessageBody));
+
+        $decodedBody = json_decode($this->capturedMessageBody);
+        $this->assertNotNull($decodedBody->pointer);
+        $this->assertEquals('App\\Jobs\\SmallJob', $decodedBody->job);
+    }
+
+    protected function simulateVaporQueueDetection(string $body): bool
+    {
+        $messageId = 'test-message-id';
+        $job = json_decode($body)->job ?? null;
+
+        return $messageId && $job;
+    }
+
+    protected function setUpDiskStorageMocks(): void
+    {
+        $this->mockedFilesystemAdapter->shouldReceive('disk')
+            ->with('s3')
+            ->andReturnSelf();
+
+        $this->mockedFilesystemAdapter->shouldReceive('put')
+            ->once();
+
+        $this->mockedContainer->shouldReceive('make')
+            ->with('filesystem')
+            ->andReturn($this->mockedFilesystemAdapter);
+
+        $this->mockedSqsClient->shouldReceive('sendMessage')
+            ->with(Mockery::on(function ($arguments) {
+                $this->capturedMessageBody = $arguments['MessageBody'];
+
+                return true;
+            }))
+            ->once()
+            ->andReturnSelf();
+
+        $this->mockedSqsClient->shouldReceive('get')
+            ->once();
+    }
+
+    protected function createQueue(bool $alwaysStore = false): SqsDiskQueue
+    {
+        $diskOptions = [
+            'always_store' => $alwaysStore,
+            'cleanup' => true,
+            'disk' => 's3',
+            'prefix' => 'queue-jobs',
+        ];
+
+        $queue = new SqsDiskQueue($this->mockedSqsClient, 'default', $diskOptions);
+        $queue->setContainer($this->mockedContainer);
+
+        return $queue;
+    }
+}


### PR DESCRIPTION
Summary
- Fix Laravel Vapor Core v2.41.0+ compatibility issue (#9) by including job property in pointer payloads
- Upgrade minimum PHP version to 8.4
- Upgrade PHPUnit to v12
- Clean up composer.json dependencies

Background:

Vapor Core v2.41.0 changed CliHandlerFactory::make() to require both messageId AND body->job to identify queue jobs. When this package stores large payloads to disk, the SQS message body only contained {"pointer": "..."} which lacked the job property, causing Vapor to treat these as unknown custom events.

The fix:

Before:

{"pointer": "prefix/uuid.json"}

After:

{"pointer": "prefix/uuid.json", "job": "Illuminate\\Queue\\CallQueuedHandler@call"}

This change is backward compatible with older Vapor Core versions and non-Vapor environments.