### PR TITLE
Resolve issue when release is called on Vapor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "laravel/pint": "^1.8",
+        "laravel/vapor-core": "^2.44",
         "mockery/mockery": "^1.6",
         "orchestra/testbench": "^10.0 || ^11.0",
         "phpunit/phpunit": "^13.0"

--- a/src/ResolvesPointers.php
+++ b/src/ResolvesPointers.php
@@ -5,10 +5,37 @@ declare(strict_types=1);
 namespace DefectiveCode\LaravelSqsExtended;
 
 use Illuminate\Support\Arr;
+use League\Flysystem\UnableToWriteFile;
 use Illuminate\Filesystem\FilesystemAdapter;
 
 trait ResolvesPointers
 {
+    /**
+     * The max length of a SQS message before it must be stored as a pointer.
+     *
+     * @var int
+     */
+    public const MAX_SQS_LENGTH = 250000;
+
+    protected function resolveMessageBody(string $payload): string
+    {
+        if (strlen($payload) < self::MAX_SQS_LENGTH && ! Arr::get($this->diskOptions, 'always_store')) {
+            return $payload;
+        }
+
+        $decodedPayload = json_decode($payload);
+        $filepath = Arr::get($this->diskOptions, 'prefix', '')."/{$decodedPayload->uuid}.json";
+
+        if ($this->resolveDisk()->put($filepath, $payload) === false) {
+            throw UnableToWriteFile::atLocation($filepath);
+        }
+
+        return json_encode([
+            'pointer' => $filepath,
+            'job' => $decodedPayload->job ?? null,
+        ]);
+    }
+
     /**
      * Resolves the job payload pointer.
      */

--- a/src/SqsDiskBaseJob.php
+++ b/src/SqsDiskBaseJob.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace DefectiveCode\LaravelSqsExtended;
 
 use Aws\Sqs\SqsClient;
-use Illuminate\Container\Container;
 use Illuminate\Support\Arr;
+use Illuminate\Container\Container;
 
 trait SqsDiskBaseJob
 {

--- a/src/SqsDiskConnector.php
+++ b/src/SqsDiskConnector.php
@@ -6,6 +6,7 @@ namespace DefectiveCode\LaravelSqsExtended;
 
 use Aws\Sqs\SqsClient;
 use Illuminate\Support\Arr;
+use Illuminate\Contracts\Queue\Queue;
 use Illuminate\Queue\Connectors\SqsConnector;
 use Illuminate\Queue\Connectors\ConnectorInterface;
 
@@ -15,7 +16,7 @@ class SqsDiskConnector extends SqsConnector implements ConnectorInterface
      * Establish a queue connection.
      *
      *
-     * @return \Illuminate\Contracts\Queue\Queue
+     * @return Queue
      */
     public function connect(array $config)
     {

--- a/src/SqsDiskQueue.php
+++ b/src/SqsDiskQueue.php
@@ -4,23 +4,16 @@ declare(strict_types=1);
 
 namespace DefectiveCode\LaravelSqsExtended;
 
-use Aws\Sqs\SqsClient;
 use DateInterval;
+use Aws\Sqs\SqsClient;
 use DateTimeInterface;
-use Illuminate\Contracts\Queue\Job;
-use Illuminate\Queue\SqsQueue;
 use Illuminate\Support\Arr;
+use Illuminate\Queue\SqsQueue;
+use Illuminate\Contracts\Queue\Job;
 
 class SqsDiskQueue extends SqsQueue
 {
     use ResolvesPointers;
-
-    /**
-     * The max length of a SQS message before it must be stored as a pointer.
-     *
-     * @var int
-     */
-    public const MAX_SQS_LENGTH = 250000;
 
     /**
      * The disk options to save large payloads.
@@ -62,19 +55,8 @@ class SqsDiskQueue extends SqsQueue
     {
         $message = [
             'QueueUrl' => $this->getQueue($queue),
-            'MessageBody' => $payload,
+            'MessageBody' => $this->resolveMessageBody($payload),
         ];
-
-        if (strlen($payload) >= self::MAX_SQS_LENGTH || Arr::get($this->diskOptions, 'always_store')) {
-            $decodedPayload = json_decode($payload);
-            $filepath = Arr::get($this->diskOptions, 'prefix', '')."/{$decodedPayload->uuid}.json";
-            $this->resolveDisk()->put($filepath, $payload);
-
-            $message['MessageBody'] = json_encode([
-                'pointer' => $filepath,
-                'job' => $decodedPayload->job ?? null,
-            ]);
-        }
 
         if ($delay) {
             $message['DelaySeconds'] = $this->secondsUntil($delay);

--- a/src/VaporSqsDiskJob.php
+++ b/src/VaporSqsDiskJob.php
@@ -5,9 +5,36 @@ declare(strict_types=1);
 namespace DefectiveCode\LaravelSqsExtended;
 
 use Laravel\Vapor\Queue\VaporJob;
+use Laravel\Vapor\Queue\JobAttempts;
 use Illuminate\Contracts\Queue\Job as JobContract;
 
 class VaporSqsDiskJob extends VaporJob implements JobContract
 {
     use SqsDiskBaseJob;
+
+    public function release($delay = 0): void
+    {
+        $this->released = true;
+
+        $payload = $this->payload();
+
+        $payload['attempts'] = $this->attempts();
+
+        $body = $this->resolveMessageBody(json_encode($payload));
+
+        $this->sqs->deleteMessage([
+            'QueueUrl' => $this->queue,
+            'ReceiptHandle' => $this->job['ReceiptHandle'],
+        ]);
+
+        $jobId = $this->sqs->sendMessage([
+            'QueueUrl' => $this->queue,
+            'MessageBody' => $body,
+            'DelaySeconds' => $this->secondsUntil($delay),
+        ])->get('MessageId');
+
+        $this->container
+            ->make(JobAttempts::class)
+            ->transfer($this, $jobId);
+    }
 }

--- a/src/VaporWorkCommand.php
+++ b/src/VaporWorkCommand.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace DefectiveCode\LaravelSqsExtended;
 
+use Laravel\Vapor\Queue\VaporJob;
 use Laravel\Vapor\Console\Commands\VaporWorkCommand as LaravelVaporWorkCommand;
 
 class VaporWorkCommand extends LaravelVaporWorkCommand
@@ -12,7 +13,7 @@ class VaporWorkCommand extends LaravelVaporWorkCommand
      * Marshal the job with the given message ID.
      *
      *
-     * @return \Laravel\Vapor\Queue\VaporJob
+     * @return VaporJob
      */
     protected function marshalJob(array $message)
     {

--- a/tests/ResolvesPointersTest.php
+++ b/tests/ResolvesPointersTest.php
@@ -9,6 +9,7 @@ use ReflectionMethod;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Filesystem\FilesystemManager;
+use DefectiveCode\LaravelSqsExtended\ResolvesPointers;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Illuminate\Contracts\Container\Container as ContainerContract;
 
@@ -67,7 +68,7 @@ class ResolvesPointersTest extends TestCase
     {
         return new class($job, $diskOptions)
         {
-            use \DefectiveCode\LaravelSqsExtended\ResolvesPointers;
+            use ResolvesPointers;
 
             public ContainerContract $container;
 

--- a/tests/VaporSqsDiskJobTest.php
+++ b/tests/VaporSqsDiskJobTest.php
@@ -6,9 +6,13 @@ namespace DefectiveCode\LaravelSqsExtended\Tests;
 
 use Mockery;
 use Aws\Sqs\SqsClient;
+use Mockery\MockInterface;
 use Illuminate\Container\Container;
+use Laravel\Vapor\Queue\JobAttempts;
+use League\Flysystem\UnableToWriteFile;
 use Illuminate\Filesystem\FilesystemAdapter;
 use DefectiveCode\LaravelSqsExtended\SqsDiskQueue;
+use DefectiveCode\LaravelSqsExtended\VaporSqsDiskJob;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 
 class VaporSqsDiskJobTest extends TestCase
@@ -96,6 +100,182 @@ class VaporSqsDiskJobTest extends TestCase
         $decodedBody = json_decode($this->capturedMessageBody);
         $this->assertNotNull($decodedBody->pointer);
         $this->assertEquals('App\\Jobs\\SmallJob', $decodedBody->job);
+    }
+
+    public function testItReleasesAnOversizedPayloadAsAPointer(): void
+    {
+        $payload = json_encode([
+            'uuid' => 'release-uuid-123',
+            'job' => 'Illuminate\\Queue\\CallQueuedHandler@call',
+            'data' => ['command' => base64_encode(random_bytes(262144))],
+        ]);
+
+        $storedPayload = null;
+
+        $this->mockedFilesystemAdapter->shouldReceive('disk')
+            ->with('s3')
+            ->andReturnSelf();
+
+        $this->mockedFilesystemAdapter->shouldReceive('get')
+            ->with('queue-jobs/release-uuid-123.json')
+            ->once()
+            ->andReturn($payload);
+
+        $this->mockedFilesystemAdapter->shouldReceive('put')
+            ->with('queue-jobs/release-uuid-123.json', Mockery::on(function ($contents) use (&$storedPayload) {
+                $storedPayload = $contents;
+
+                return true;
+            }))
+            ->once();
+
+        $this->mockedContainer->shouldReceive('make')
+            ->with('filesystem')
+            ->andReturn($this->mockedFilesystemAdapter);
+
+        $this->expectJobAttemptsTransfer();
+        $this->expectReleaseSqsCalls();
+
+        $this->createJob(json_encode([
+            'pointer' => 'queue-jobs/release-uuid-123.json',
+            'job' => 'Illuminate\\Queue\\CallQueuedHandler@call',
+        ]))->release();
+
+        $decodedBody = json_decode($this->capturedMessageBody);
+
+        $this->assertEquals('queue-jobs/release-uuid-123.json', $decodedBody->pointer);
+        $this->assertEquals('Illuminate\\Queue\\CallQueuedHandler@call', $decodedBody->job);
+        $this->assertLessThan(VaporSqsDiskJob::MAX_SQS_LENGTH, strlen($this->capturedMessageBody));
+        $this->assertEquals(1, json_decode($storedPayload)->attempts);
+    }
+
+    public function testItReleasesASmallPayloadInline(): void
+    {
+        $payload = json_encode([
+            'uuid' => 'release-uuid-456',
+            'job' => 'App\\Jobs\\SmallJob',
+            'data' => ['key' => 'value'],
+        ]);
+
+        $this->mockedContainer->shouldReceive('make')
+            ->with('filesystem')
+            ->never();
+
+        $this->expectJobAttemptsTransfer();
+        $this->expectReleaseSqsCalls();
+
+        $this->createJob($payload)->release();
+
+        $decodedBody = json_decode($this->capturedMessageBody);
+
+        $this->assertEquals('release-uuid-456', $decodedBody->uuid);
+        $this->assertEquals(['key' => 'value'], (array) $decodedBody->data);
+        $this->assertEquals(1, $decodedBody->attempts);
+    }
+
+    public function testItDoesNotDeleteTheMessageWhenTheDiskWriteFails(): void
+    {
+        $payload = json_encode([
+            'uuid' => 'release-uuid-789',
+            'job' => 'Illuminate\\Queue\\CallQueuedHandler@call',
+            'data' => ['command' => base64_encode(random_bytes(262144))],
+        ]);
+
+        $this->mockedFilesystemAdapter->shouldReceive('disk')
+            ->with('s3')
+            ->andReturnSelf();
+
+        $this->mockedFilesystemAdapter->shouldReceive('get')
+            ->with('queue-jobs/release-uuid-789.json')
+            ->once()
+            ->andReturn($payload);
+
+        $this->mockedFilesystemAdapter->shouldReceive('put')
+            ->once()
+            ->andReturnFalse();
+
+        $this->mockedContainer->shouldReceive('make')
+            ->with('filesystem')
+            ->andReturn($this->mockedFilesystemAdapter);
+
+        $this->expectJobAttemptsGet();
+
+        $this->mockedSqsClient->shouldNotReceive('deleteMessage');
+        $this->mockedSqsClient->shouldNotReceive('sendMessage');
+
+        $this->expectException(UnableToWriteFile::class);
+
+        $this->createJob(json_encode([
+            'pointer' => 'queue-jobs/release-uuid-789.json',
+            'job' => 'Illuminate\\Queue\\CallQueuedHandler@call',
+        ]))->release();
+    }
+
+    protected function expectReleaseSqsCalls(): void
+    {
+        $this->mockedSqsClient->shouldReceive('deleteMessage')
+            ->once();
+
+        $this->mockedSqsClient->shouldReceive('sendMessage')
+            ->with(Mockery::on(function ($arguments) {
+                $this->capturedMessageBody = $arguments['MessageBody'];
+
+                return true;
+            }))
+            ->once()
+            ->andReturnSelf();
+
+        $this->mockedSqsClient->shouldReceive('get')
+            ->with('MessageId')
+            ->once()
+            ->andReturn('new-message-id');
+    }
+
+    protected function expectJobAttemptsTransfer(): void
+    {
+        $this->expectJobAttemptsGet()
+            ->shouldReceive('transfer')
+            ->with(Mockery::type(VaporSqsDiskJob::class), 'new-message-id')
+            ->once();
+    }
+
+    protected function expectJobAttemptsGet(): MockInterface
+    {
+        $jobAttempts = Mockery::mock(JobAttempts::class);
+
+        $jobAttempts->shouldReceive('get')
+            ->andReturn(0);
+
+        $this->mockedContainer->shouldReceive('make')
+            ->with(JobAttempts::class)
+            ->andReturn($jobAttempts);
+
+        return $jobAttempts;
+    }
+
+    protected function createJob(string $body): VaporSqsDiskJob
+    {
+        $job = [
+            'Body' => $body,
+            'MD5OfBody' => md5($body),
+            'ReceiptHandle' => 'receipt-handle',
+            'MessageId' => 'e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81',
+            'Attributes' => ['ApproximateReceiveCount' => 1],
+        ];
+
+        return new VaporSqsDiskJob(
+            $this->mockedContainer,
+            $this->mockedSqsClient,
+            $job,
+            'connection',
+            'queue',
+            [
+                'always_store' => false,
+                'cleanup' => true,
+                'disk' => 's3',
+                'prefix' => 'queue-jobs',
+            ]
+        );
     }
 
     protected function simulateVaporQueueDetection(string $body): bool


### PR DESCRIPTION
## Summary

- preserve disk-backed payloads when Vapor releases an SQS job
- retain Vapor job attempt tracking when the message is requeued
- share pointer serialization between standard queue pushes and Vapor releases
- abort before deleting the original SQS message when a disk write fails
- add regression coverage for oversized, inline, and failed-write release paths
