### PR TITLE
Offload batched payloads and derive the size threshold from the queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@
 
 # Introduction
 
-Laravel SQS extended is a Laravel queue driver that was designed to work around the AWS SQS 256KB payload size limits. This queue driver will automatically serialize large payloads to a disk (typically S3) and then unserialize them at run time.
+Laravel SQS extended is a Laravel queue driver that was designed to work around the AWS SQS payload size limits. This queue driver will automatically serialize large payloads to a disk (typically S3) and then unserialize them at run time.
+
+The threshold is read from the queue's own `MaximumMessageSize` attribute, so queues raised to the 1 MiB maximum offload only what genuinely will not fit. Set `disk_options.max_size` to pin it to a fixed byte count instead, which also skips the attribute lookup.
 
 # Documentation
 

--- a/docs/en.md
+++ b/docs/en.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-Laravel SQS Extended is a Laravel queue driver that was designed to work around the AWS SQS 256KB payload size limits. This queue driver will automatically serialize large payloads to a disk (typically S3) and then unserialize them at run time. This package took inspiration from https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-s3-messages.html.
+Laravel SQS Extended is a Laravel queue driver that was designed to work around the AWS SQS payload size limits. This queue driver will automatically serialize large payloads to a disk (typically S3) and then unserialize them at run time. This package took inspiration from https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-s3-messages.html.
 
 ## Migration from Simple SQS Extended Client
 
@@ -33,10 +33,12 @@ The old configuration is backwards compatible with the new package. The only cha
   | configuration options from the built in Laravel SQS queue driver.  The only added
   | option is `disk_options` which are explained below.
   |
-  | always_store: Determines if all payloads should be stored on a disk regardless if they are over SQS's 256KB limit.
+  | always_store: Determines if all payloads should be stored on a disk regardless of the queue's size limit.
   | cleanup:      Determines if the payload files should be removed from the disk once the job is processed. Leaveing the
   |                 files behind can be useful to replay the queue jobs later for debugging reasons.
   | disk:         The disk to save SQS payloads to.  This disk should be configured in your Laravel filesystems.php config file.
+  | max_size:     Optional. Pins the offload threshold to a fixed number of bytes. When omitted, the threshold is read from
+  |                 the queue itself. See "Payload size threshold" below.
   | prefix        The prefix (folder) to store the payloads with.  This is useful if you are sharing a disk with other SQS queues.
   |                 Using a prefix allows for the queue:clear command to destroy the files separately from other sqs-disk backed queues
   |                 sharing the same disk.
@@ -60,4 +62,36 @@ The old configuration is backwards compatible with the new package. The only cha
   ],
 ```
 
-4. Boot up your queues and profit without having to worry about SQS's 256KB limit 🥳
+4. Boot up your queues and profit without having to worry about SQS's payload limit 🥳
+
+## Payload size threshold
+
+AWS raised the maximum SQS payload from 256 KiB to 1 MiB in August 2025, but `MaximumMessageSize` is a per-queue attribute — queues created before that change keep the older 262144 byte value until you raise it. Rather than assume either limit, this package reads the attribute from the queue and offloads only what genuinely will not fit.
+
+The threshold is resolved in the following order, and the first match wins. A payload is stored on the disk when its length is greater than or equal to the resolved threshold.
+
+| Condition                                       | Threshold               | Reads the queue attribute |
+| ----------------------------------------------- | ----------------------- | ------------------------- |
+| `always_store` is `true`                        | Every payload is stored | No                        |
+| `max_size` is set                               | The configured value    | No                        |
+| Queue reports `262144` (the pre-2025 default)   | 250000                  | Yes                       |
+| Queue reports `1048576` (raised to the maximum) | 1036432                 | Yes                       |
+| Attribute cannot be read                        | 250000                  | Attempted once            |
+
+The reserved headroom of 12144 bytes covers per-message overhead, and is sized so a queue left at the 262144 byte default resolves to the 250000 byte threshold used by earlier versions of this package. Upgrading does not change behavior until you raise the queue's own limit.
+
+### Permissions
+
+Reading the attribute requires `sqs:GetQueueAttributes`. The result is cached in memory per queue, so this costs one call per queue for the lifetime of the process rather than one call per job.
+
+If the attribute cannot be read — a narrow IAM policy, or an SQS emulator that does not implement it — the driver falls back to the 250000 byte threshold and continues dispatching. Set `max_size` to skip the lookup entirely if you would rather not grant the permission.
+
+### Raising a queue's limit
+
+```
+aws sqs set-queue-attributes \
+    --queue-url https://sqs.us-east-1.amazonaws.com/your-account-id/your-queue \
+    --attributes MaximumMessageSize=1048576
+```
+
+Note that SQS meters usage in 64 KB chunks, so a single 1 MiB message bills as 16 requests. Storing large payloads on a disk is often still the cheaper path.

--- a/src/ResolvesPointers.php
+++ b/src/ResolvesPointers.php
@@ -5,21 +5,36 @@ declare(strict_types=1);
 namespace DefectiveCode\LaravelSqsExtended;
 
 use Illuminate\Support\Arr;
+use Aws\Exception\AwsException;
 use League\Flysystem\UnableToWriteFile;
 use Illuminate\Filesystem\FilesystemAdapter;
 
 trait ResolvesPointers
 {
     /**
-     * The max length of a SQS message before it must be stored as a pointer.
+     * The fallback max length of a SQS message before it must be stored as a pointer.
      *
      * @var int
      */
     public const MAX_SQS_LENGTH = 250000;
 
-    protected function resolveMessageBody(string $payload): string
+    /**
+     * Headroom reserved below the queue's MaximumMessageSize for per-message overhead.
+     *
+     * Sized so a queue left at the 262144 byte default resolves to MAX_SQS_LENGTH.
+     *
+     * @var int
+     */
+    public const MESSAGE_SIZE_MARGIN = 12144;
+
+    /**
+     * Cache of resolved thresholds, keyed by queue URL.
+     */
+    protected array $queueMaxLengths = [];
+
+    protected function resolveMessageBody(string $payload, ?string $queueUrl = null): string
     {
-        if (strlen($payload) < self::MAX_SQS_LENGTH && ! Arr::get($this->diskOptions, 'always_store')) {
+        if (strlen($payload) < $this->maxSqsLength($queueUrl) && ! Arr::get($this->diskOptions, 'always_store')) {
             return $payload;
         }
 
@@ -34,6 +49,44 @@ trait ResolvesPointers
             'pointer' => $filepath,
             'job' => $decodedPayload->job ?? null,
         ]);
+    }
+
+    /**
+     * Resolves the payload length at which a message must become a pointer.
+     */
+    protected function maxSqsLength(?string $queueUrl): int
+    {
+        if ($configured = Arr::get($this->diskOptions, 'max_size')) {
+            return (int) $configured;
+        }
+
+        if ($queueUrl === null) {
+            return self::MAX_SQS_LENGTH;
+        }
+
+        return $this->queueMaxLengths[$queueUrl] ??= $this->detectMaxSqsLength($queueUrl);
+    }
+
+    /**
+     * Reads the queue's MaximumMessageSize, less the reserved headroom.
+     *
+     * Falls back to MAX_SQS_LENGTH when the attribute is unreadable, so that
+     * neither a narrow IAM policy nor an SQS emulator can stall dispatch.
+     */
+    protected function detectMaxSqsLength(string $queueUrl): int
+    {
+        try {
+            $maximum = (int) $this->sqs->getQueueAttributes([
+                'QueueUrl' => $queueUrl,
+                'AttributeNames' => ['MaximumMessageSize'],
+            ])['Attributes']['MaximumMessageSize'];
+        } catch (AwsException) {
+            return self::MAX_SQS_LENGTH;
+        }
+
+        return $maximum > self::MESSAGE_SIZE_MARGIN
+            ? $maximum - self::MESSAGE_SIZE_MARGIN
+            : self::MAX_SQS_LENGTH;
     }
 
     /**

--- a/src/SqsDiskQueue.php
+++ b/src/SqsDiskQueue.php
@@ -53,9 +53,11 @@ class SqsDiskQueue extends SqsQueue
      */
     public function pushRaw($payload, $queue = null, array $options = [], $delay = 0)
     {
+        $queueUrl = $this->getQueue($queue);
+
         $message = [
-            'QueueUrl' => $this->getQueue($queue),
-            'MessageBody' => $this->resolveMessageBody($payload),
+            'QueueUrl' => $queueUrl,
+            'MessageBody' => $this->resolveMessageBody($payload, $queueUrl),
         ];
 
         if ($delay) {
@@ -85,6 +87,21 @@ class SqsDiskQueue extends SqsQueue
                 return $this->pushRaw($payload, $queue, [], $delay);
             }
         );
+    }
+
+    /**
+     * Build a single entry for the SendMessageBatch API.
+     *
+     * @param  string  $id
+     * @param  string|null  $queue
+     * @return array
+     */
+    protected function prepareSendMessageBatchEntry($id, array $message, $queue)
+    {
+        return [
+            ...parent::prepareSendMessageBatchEntry($id, $message, $queue),
+            'MessageBody' => $this->resolveMessageBody($message['payload'], $this->getQueue($queue)),
+        ];
     }
 
     /**

--- a/src/VaporSqsDiskJob.php
+++ b/src/VaporSqsDiskJob.php
@@ -20,7 +20,7 @@ class VaporSqsDiskJob extends VaporJob implements JobContract
 
         $payload['attempts'] = $this->attempts();
 
-        $body = $this->resolveMessageBody(json_encode($payload));
+        $body = $this->resolveMessageBody(json_encode($payload), $this->queue);
 
         $this->sqs->deleteMessage([
             'QueueUrl' => $this->queue,

--- a/tests/SqsDiskQueueTest.php
+++ b/tests/SqsDiskQueueTest.php
@@ -6,6 +6,7 @@ namespace DefectiveCode\LaravelSqsExtended\Tests;
 
 use Mockery;
 use Aws\Result;
+use ArrayObject;
 use Aws\Command;
 use Aws\Sqs\SqsClient;
 use Aws\Exception\AwsException;
@@ -231,12 +232,7 @@ class SqsDiskQueueTest extends TestCase
         $this->mockedFilesystemAdapter->shouldReceive('disk')
             ->never();
 
-        $this->mockedSqsClient->shouldReceive('sendMessageBatch')
-            ->with(Mockery::on(function ($arguments) {
-                return json_decode($arguments['Entries'][0]['MessageBody'])->job === 'foo';
-            }))
-            ->once()
-            ->andReturn(new Result(['Successful' => []]));
+        $bodies = $this->captureBatchedMessageBodies();
 
         $diskOptions = [
             'always_store' => false,
@@ -248,6 +244,10 @@ class SqsDiskQueueTest extends TestCase
         $sqsDiskQueue = new SqsDiskQueue($this->mockedSqsClient, 'default', $diskOptions);
         $sqsDiskQueue->setContainer($this->mockedContainer);
         $sqsDiskQueue->bulk(['foo']);
+
+        $this->assertCount(1, $bodies);
+        $this->assertEquals('foo', json_decode($bodies[0])->job);
+        $this->assertObjectNotHasProperty('pointer', json_decode($bodies[0]));
     }
 
     public function testItPushesLargeBatchedPayloadsToADisk(): void
@@ -263,14 +263,7 @@ class SqsDiskQueueTest extends TestCase
             ->with('filesystem')
             ->andReturn($this->mockedFilesystemAdapter);
 
-        $this->mockedSqsClient->shouldReceive('sendMessageBatch')
-            ->with(Mockery::on(function ($arguments) {
-                $body = json_decode($arguments['Entries'][0]['MessageBody']);
-
-                return isset($body->pointer) && $body->job === 'foo';
-            }))
-            ->once()
-            ->andReturn(new Result(['Successful' => []]));
+        $bodies = $this->captureBatchedMessageBodies();
 
         $diskOptions = [
             'always_store' => false,
@@ -282,6 +275,12 @@ class SqsDiskQueueTest extends TestCase
         $sqsDiskQueue = new SqsDiskQueue($this->mockedSqsClient, 'default', $diskOptions);
         $sqsDiskQueue->setContainer($this->mockedContainer);
         $sqsDiskQueue->bulk(['foo'], [base64_encode(random_bytes(262144))]);
+
+        $this->assertCount(1, $bodies);
+
+        $decodedBody = json_decode($bodies[0]);
+        $this->assertEquals('foo', $decodedBody->job);
+        $this->assertNotNull($decodedBody->pointer);
     }
 
     public function testItKeepsPayloadsInlineWhenTheQueueAllowsALargerMaximumMessageSize(): void
@@ -493,5 +492,40 @@ class SqsDiskQueueTest extends TestCase
         $sqsDiskQueue = new SqsDiskQueue($this->mockedSqsClient, 'default', $diskOptions);
         $sqsDiskQueue->setContainer($this->mockedContainer);
         $sqsDiskQueue->clear('default');
+    }
+
+    /**
+     * Collect the bodies bulk() sends, whichever SQS API the framework reaches for.
+     *
+     * Laravel dispatches batches through SendMessageBatch from 13.19 onward, and
+     * one SendMessage per job before that.
+     */
+    protected function captureBatchedMessageBodies(): ArrayObject
+    {
+        $bodies = new ArrayObject;
+
+        $this->mockedSqsClient->shouldReceive('sendMessage')
+            ->with(Mockery::on(function ($arguments) use ($bodies) {
+                $bodies->append($arguments['MessageBody']);
+
+                return true;
+            }))
+            ->andReturnSelf();
+
+        $this->mockedSqsClient->shouldReceive('get')
+            ->with('MessageId')
+            ->andReturn('message-id');
+
+        $this->mockedSqsClient->shouldReceive('sendMessageBatch')
+            ->with(Mockery::on(function ($arguments) use ($bodies) {
+                foreach ($arguments['Entries'] as $entry) {
+                    $bodies->append($entry['MessageBody']);
+                }
+
+                return true;
+            }))
+            ->andReturn(new Result(['Successful' => []]));
+
+        return $bodies;
     }
 }

--- a/tests/SqsDiskQueueTest.php
+++ b/tests/SqsDiskQueueTest.php
@@ -6,7 +6,9 @@ namespace DefectiveCode\LaravelSqsExtended\Tests;
 
 use Mockery;
 use Aws\Result;
+use Aws\Command;
 use Aws\Sqs\SqsClient;
+use Aws\Exception\AwsException;
 use Illuminate\Container\Container;
 use Illuminate\Filesystem\FilesystemAdapter;
 use DefectiveCode\LaravelSqsExtended\SqsDiskJob;
@@ -57,6 +59,8 @@ class SqsDiskQueueTest extends TestCase
         $this->mockedSqsClient = Mockery::mock(SqsClient::class);
         $this->mockedFilesystemAdapter = Mockery::mock(FilesystemAdapter::class);
         $this->mockedContainer = Mockery::mock(Container::class)->makePartial();
+
+        $this->allowQueueMaxSize($this->mockedSqsClient, '/default');
     }
 
     public function testItDoesntPushToADiskIfTheAlwaysStoreIsDisabledAndThePayloadIsntLarge(): void
@@ -220,6 +224,209 @@ class SqsDiskQueueTest extends TestCase
         $sqsDiskQueue = new SqsDiskQueue($this->mockedSqsClient, 'default', $diskOptions);
         $sqsDiskQueue->setContainer($this->mockedContainer);
         $sqsDiskQueue->later(10, 'foo');
+    }
+
+    public function testItDoesntPushBatchedPayloadsToADiskWhenTheyArentLarge(): void
+    {
+        $this->mockedFilesystemAdapter->shouldReceive('disk')
+            ->never();
+
+        $this->mockedSqsClient->shouldReceive('sendMessageBatch')
+            ->with(Mockery::on(function ($arguments) {
+                return json_decode($arguments['Entries'][0]['MessageBody'])->job === 'foo';
+            }))
+            ->once()
+            ->andReturn(new Result(['Successful' => []]));
+
+        $diskOptions = [
+            'always_store' => false,
+            'cleanup' => true,
+            'disk' => 's3',
+            'prefix' => 'prefix',
+        ];
+
+        $sqsDiskQueue = new SqsDiskQueue($this->mockedSqsClient, 'default', $diskOptions);
+        $sqsDiskQueue->setContainer($this->mockedContainer);
+        $sqsDiskQueue->bulk(['foo']);
+    }
+
+    public function testItPushesLargeBatchedPayloadsToADisk(): void
+    {
+        $this->mockedFilesystemAdapter->shouldReceive('disk')
+            ->with('s3')
+            ->andReturnSelf();
+
+        $this->mockedFilesystemAdapter->shouldReceive('put')
+            ->once();
+
+        $this->mockedContainer->shouldReceive('make')
+            ->with('filesystem')
+            ->andReturn($this->mockedFilesystemAdapter);
+
+        $this->mockedSqsClient->shouldReceive('sendMessageBatch')
+            ->with(Mockery::on(function ($arguments) {
+                $body = json_decode($arguments['Entries'][0]['MessageBody']);
+
+                return isset($body->pointer) && $body->job === 'foo';
+            }))
+            ->once()
+            ->andReturn(new Result(['Successful' => []]));
+
+        $diskOptions = [
+            'always_store' => false,
+            'cleanup' => true,
+            'disk' => 's3',
+            'prefix' => 'prefix',
+        ];
+
+        $sqsDiskQueue = new SqsDiskQueue($this->mockedSqsClient, 'default', $diskOptions);
+        $sqsDiskQueue->setContainer($this->mockedContainer);
+        $sqsDiskQueue->bulk(['foo'], [base64_encode(random_bytes(262144))]);
+    }
+
+    public function testItKeepsPayloadsInlineWhenTheQueueAllowsALargerMaximumMessageSize(): void
+    {
+        $sqsClient = Mockery::mock(SqsClient::class);
+        $this->allowQueueMaxSize($sqsClient, '/default', 1048576);
+
+        $this->mockedFilesystemAdapter->shouldReceive('disk')
+            ->never();
+
+        $sqsClient->shouldReceive('sendMessage')
+            ->with([
+                'QueueUrl' => '/default',
+                'MessageBody' => $this->mockedLargePayload,
+            ])
+            ->once()
+            ->andReturnSelf();
+
+        $sqsClient->shouldReceive('get')
+            ->once();
+
+        $diskOptions = [
+            'always_store' => false,
+            'cleanup' => true,
+            'disk' => 's3',
+            'prefix' => 'prefix',
+        ];
+
+        $sqsDiskQueue = new SqsDiskQueue($sqsClient, 'default', $diskOptions);
+        $sqsDiskQueue->setContainer($this->mockedContainer);
+        $sqsDiskQueue->pushRaw($this->mockedLargePayload);
+    }
+
+    public function testItPrefersTheConfiguredMaxSizeOverTheQueueAttribute(): void
+    {
+        $sqsClient = Mockery::mock(SqsClient::class);
+        $sqsClient->shouldNotReceive('getQueueAttributes');
+
+        $this->mockedFilesystemAdapter->shouldReceive('disk')
+            ->with('s3')
+            ->andReturnSelf();
+
+        $this->mockedFilesystemAdapter->shouldReceive('put')
+            ->with('prefix/e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81.json', $this->mockedPayload)
+            ->once();
+
+        $this->mockedContainer->shouldReceive('make')
+            ->with('filesystem')
+            ->andReturn($this->mockedFilesystemAdapter);
+
+        $sqsClient->shouldReceive('sendMessage')
+            ->with([
+                'QueueUrl' => '/default',
+                'MessageBody' => $this->mockedPointerPayload,
+            ])
+            ->once()
+            ->andReturnSelf();
+
+        $sqsClient->shouldReceive('get')
+            ->once();
+
+        $diskOptions = [
+            'always_store' => false,
+            'cleanup' => true,
+            'disk' => 's3',
+            'prefix' => 'prefix',
+            'max_size' => 10,
+        ];
+
+        $sqsDiskQueue = new SqsDiskQueue($sqsClient, 'default', $diskOptions);
+        $sqsDiskQueue->setContainer($this->mockedContainer);
+        $sqsDiskQueue->pushRaw($this->mockedPayload);
+    }
+
+    public function testItFallsBackToTheDefaultMaxLengthWhenTheQueueAttributeIsUnreadable(): void
+    {
+        $sqsClient = Mockery::mock(SqsClient::class);
+
+        $sqsClient->shouldReceive('getQueueAttributes')
+            ->once()
+            ->andThrow(new AwsException('Access denied', new Command('GetQueueAttributes')));
+
+        $this->mockedFilesystemAdapter->shouldReceive('disk')
+            ->with('s3')
+            ->andReturnSelf();
+
+        $this->mockedFilesystemAdapter->shouldReceive('put')
+            ->with('prefix/e3cd03ee-59a3-4ad8-b0aa-ee2e3808ac81.json', $this->mockedLargePayload)
+            ->once();
+
+        $this->mockedContainer->shouldReceive('make')
+            ->with('filesystem')
+            ->andReturn($this->mockedFilesystemAdapter);
+
+        $sqsClient->shouldReceive('sendMessage')
+            ->with([
+                'QueueUrl' => '/default',
+                'MessageBody' => $this->mockedPointerPayload,
+            ])
+            ->once()
+            ->andReturnSelf();
+
+        $sqsClient->shouldReceive('get')
+            ->once();
+
+        $diskOptions = [
+            'always_store' => false,
+            'cleanup' => true,
+            'disk' => 's3',
+            'prefix' => 'prefix',
+        ];
+
+        $sqsDiskQueue = new SqsDiskQueue($sqsClient, 'default', $diskOptions);
+        $sqsDiskQueue->setContainer($this->mockedContainer);
+        $sqsDiskQueue->pushRaw($this->mockedLargePayload);
+    }
+
+    public function testItOnlyReadsTheQueueAttributeOncePerQueue(): void
+    {
+        $sqsClient = Mockery::mock(SqsClient::class);
+
+        $sqsClient->shouldReceive('getQueueAttributes')
+            ->once()
+            ->andReturn(new Result([
+                'Attributes' => ['MaximumMessageSize' => '262144'],
+            ]));
+
+        $sqsClient->shouldReceive('sendMessage')
+            ->twice()
+            ->andReturnSelf();
+
+        $sqsClient->shouldReceive('get')
+            ->twice();
+
+        $diskOptions = [
+            'always_store' => false,
+            'cleanup' => true,
+            'disk' => 's3',
+            'prefix' => 'prefix',
+        ];
+
+        $sqsDiskQueue = new SqsDiskQueue($sqsClient, 'default', $diskOptions);
+        $sqsDiskQueue->setContainer($this->mockedContainer);
+        $sqsDiskQueue->pushRaw($this->mockedPayload);
+        $sqsDiskQueue->pushRaw($this->mockedPayload);
     }
 
     public function testItCreatesANewSqsDiskJobWhenPopped(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace DefectiveCode\LaravelSqsExtended\Tests;
 
+use Aws\Result;
 use Carbon\Carbon;
+use Mockery\MockInterface;
 use Illuminate\Support\Facades\Http;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
@@ -16,5 +18,20 @@ abstract class TestCase extends BaseTestCase
 
         Http::preventStrayRequests();
         Carbon::setTestNow('1988-12-15 06:00:00');
+    }
+
+    /**
+     * Allow the queue's MaximumMessageSize to be read, without requiring it.
+     */
+    protected function allowQueueMaxSize(MockInterface $sqs, string $queueUrl, int $maximumMessageSize = 262144): void
+    {
+        $sqs->shouldReceive('getQueueAttributes')
+            ->with([
+                'QueueUrl' => $queueUrl,
+                'AttributeNames' => ['MaximumMessageSize'],
+            ])
+            ->andReturn(new Result([
+                'Attributes' => ['MaximumMessageSize' => (string) $maximumMessageSize],
+            ]));
     }
 }

--- a/tests/VaporSqsDiskJobTest.php
+++ b/tests/VaporSqsDiskJobTest.php
@@ -34,6 +34,9 @@ class VaporSqsDiskJobTest extends TestCase
         $this->mockedSqsClient = Mockery::mock(SqsClient::class);
         $this->mockedFilesystemAdapter = Mockery::mock(FilesystemAdapter::class);
         $this->mockedContainer = Mockery::mock(Container::class)->makePartial();
+
+        $this->allowQueueMaxSize($this->mockedSqsClient, '/default');
+        $this->allowQueueMaxSize($this->mockedSqsClient, 'queue');
     }
 
     public function testOldPointerFormatFailsVaporDetection(): void


### PR DESCRIPTION
rrected the three stale "256KB" claims in the intro, the always_store comment, and the closing line, and added max_size to the config comment block.

The docs file was Prettier-clean before my edits and my additions weren't, so I ran prettier --write on it — --check now passes on both docs/en.md and README.md. Pint clean, 31 tests / 89 assertions passing.

One note on the table's phrasing that I tightened between my message and the docs: the boundary is strlen($payload) < threshold stays inline, so a payload lands on disk when it's greater than or equal to the threshold. The docs say it that way.

Full diff for 2.1.0:

 README.md                     |   4 +-
 docs/en.md                    |  40 +++++++-
 src/ResolvesPointers.php      |  59 +++++++++++-
 src/SqsDiskQueue.php          |  21 ++++-
**Batched dispatch bypassed disk offload entirely.** Laravel 13.19 rewrote `SqsQueue::bulk()` to use the `SendMessageBatch` API. That path builds message bodies in `prepareSendMessageBatchEntry()` and never calls `pushRaw()` — the only method `SqsDiskQueue` overrode. Any job dispatched via `Bus::batch()` with a payload over the queue limit went to SQS raw and was rejected:

```
InvalidParameterValue: One or more parameters cannot be validated.
Reason: Message must be shorter than 262144 bytes.
```

Fixed by overriding `prepareSendMessageBatchEntry()` so batched entries run through `resolveMessageBody()`, producing bodies byte-identical to the non-batched path. No consumer-side change was needed — `SqsDiskJob` already resolves pointers regardless of how the message was sent.

**The offload threshold was hardcoded at 250000 bytes.** AWS raised the maximum SQS payload from 256 KiB to 1 MiB in August 2025, but `MaximumMessageSize` is a per-queue attribute — queues created before the change keep 262144 until raised. A fixed constant is wrong in both directions. The threshold is now read from the queue itself.

## Threshold resolution

First match wins. A payload is stored on disk when its length is greater than or equal to the resolved threshold.

| Condition | Threshold | Reads queue attribute |
| --- | --- | --- |
| `always_store` is `true` | Every payload stored | No |
| `max_size` is set | The configured value | No |
| Queue reports `262144` | 250000 | Yes |
| Queue reports `1048576` | 1036432 | Yes |
| Attribute unreadable | 250000 | Attempted once |

The 12144-byte headroom covers per-message overhead and is sized so a queue left at the 262144 default resolves to exactly the 250000 threshold used by earlier versions.

## Why this is a minor, not a major

All three breaking vectors are avoided by design:

- `MAX_SQS_LENGTH` is retained as the public fallback constant, not repurposed or removed.
- Behavior on an unraised queue is byte-identical to 2.0.x — the arithmetic lands on 250000.
- The attribute read requires `sqs:GetQueueAttributes`, which the package has never needed. Rather than make that a hard runtime requirement in a minor release, a failed lookup degrades to 250000 and dispatch continues. Set `max_size` to skip the lookup entirely.

`illuminate/queue` stays at `^12.0 || ^13.0`. The batch override is inert on versions predating the `SendMessageBatch` rewrite, where `bulk()` still routes through `pushRaw()`.

## Performance

 Threshold resolution

  First match wins. A payload is stored on disk when its length is greater than or equal to the resolved threshold.

  | Condition | Threshold | Reads queue attribute |
  | --- | --- | --- |
  | `always_store` is `true` | Every payload stored | No |
  | `max_size` is set | The configured value | No |
  | Queue reports `262144` | 250000 | Yes |
  | Queue reports `1048576` | 1036432 | Yes |
  | Attribute unreadable | 250000 | Attempted once |

  The 12144-byte headroom covers per-message overhead and is sized so a queue left at the 262144 default resolves to exactly the 250000 threshold used by earlier versions.

  ## Why this is a minor, not a major

  All three breaking vectors are avoided by design:

  - `MAX_SQS_LENGTH` is retained as the public fallback constant, not repurposed or removed.
  - Behavior on an unraised queue is byte-identical to 2.0.x — the arithmetic lands on 250000.
  - The attribute read requires `sqs:GetQueueAttributes`, which the package has never needed. Rather than make that a hard runtime requirement in a minor release, a failed lookup degrades to 250000 and dispatch continues. Set `max_size` to skip the lookup entirely.

  `illuminate/queue` stays at `^12.0 || ^13.0`. The batch override is inert on versions predating the `SendMessageBatch` rewrite, where `bulk()` still routes through `pushRaw()`.

  ## Performance

  The resolved threshold is memoized per queue URL, so the lookup costs one SQS call per queue for the lifetime of the process, not one per job. On Lambda that is one call per cold start. `max_size` eliminates it.